### PR TITLE
Fix scrolling behind lightbox on mobile devices

### DIFF
--- a/assets/sass/container.sass
+++ b/assets/sass/container.sass
@@ -1,5 +1,10 @@
 @import variables
 
+html.lightbox-open
+  overflow: hidden
+  position: fixed
+  width: 100%
+
 .lightbox-backdrop
   position: fixed
   width: 100%

--- a/assets/sass/container.sass
+++ b/assets/sass/container.sass
@@ -26,6 +26,7 @@
   .lightbox-btn-close
     position: fixed
     right: 0px
+    z-index: 1
   .lightbox-btn-right
     position: absolute
     top: 50%

--- a/src/Container.jsx
+++ b/src/Container.jsx
@@ -31,12 +31,27 @@ module.exports = React.createClass({
     };
   },
   componentWillMount: function() {
-    document.documentElement.style.overflow = 'hidden';
+    const scrollTop = document.body.scrollTop;
+    this.addClass(document.documentElement, 'lightbox-open');
+    document.documentElement.style.top = `-${scrollTop}px`;
     document.body.scroll = "no"; // ie only
   },
   componentWillUnmount: function() {
-    document.documentElement.style.overflow = 'auto';
+    const scrollTop = Math.abs(parseInt(document.documentElement.style.top))
+    this.removeClass(document.documentElement, 'lightbox-open');
+    document.documentElement.style.top = null;
+    document.body.scrollTop = scrollTop
     document.body.scroll = "yes"; // ie only
+  },
+  addClass: function (element, className) {
+    const classList = element.className.split(/\s+/);
+    if (classList.indexOf(className) === -1) {
+      element.className = classList.concat(className).join(' ');
+    }
+  },
+  removeClass: function (element, className) {
+    const classList = element.className.split(/\s+/);
+    element.className = classList.filter(name => name !== className).join(' ');
   },
   handleLeftClick: function(){
     if (this.canMoveToLeft()) {


### PR DESCRIPTION
In the first commit, I simply bumped the z-index of the close button because it was impossible to close the lightbox on small mobile screens. It's kind of separate, but was needed to test better on mobile.

This fixes the page scrolling behind the lightbox on mobile devices. The way it works is by setting the HTML element's CSS `position` to `static` and setting its `top` to the body's `scrollTop`. After the lightbox is closed, the body's `scrollTop` is set back to what it was prior to the lightbox being opened. This prevents scrolling on mobile devices without the side effect of scrolling to the top of the page.

This is important to implement before swipe to navigate and pinch to zoom gestures.
