### PR TITLE
String method to renderDescriptionFunc. Updated PropTypes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lightbox-component",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/lib/components/Container.jsx
+++ b/src/lib/components/Container.jsx
@@ -31,7 +31,7 @@ export default class Container extends React.Component {
       if(!image.description) return;
       if(image.description.then){ //if promise
         image.description.then((data) => {
-          images[index] = data.data.first_name;
+          images[index] = data;
           this.setState({imagesDescriptions: images});
         });
         return;

--- a/src/lib/components/Container.jsx
+++ b/src/lib/components/Container.jsx
@@ -170,7 +170,7 @@ Container.defaultProps = {
   renderDescriptionFunc: (descriptionText) => {
     return (
       <div>
-        {descriptionText}
+        {String(descriptionText)}
       </div>
     )
   }

--- a/src/lib/components/Lightbox.jsx
+++ b/src/lib/components/Lightbox.jsx
@@ -75,7 +75,7 @@ Lightbox.propTypes = {
   images: PropTypes.arrayOf(PropTypes.shape({
     src: PropTypes.string.isRequired,
     title: PropTypes.string,
-    description: PropTypes.string,
+    description: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     thumbnail: PropTypes.string
   })).isRequired,
   showImageModifiers: PropTypes.bool,


### PR DESCRIPTION
Added a small fix to the default render description function: now converts to String to avoid errors when the description is an object, array. 
I also updated the Lightbox PropTypes because the image description can be a string or a object (promise).